### PR TITLE
app: celery app fix

### DIFF
--- a/flask_celeryext/__init__.py
+++ b/flask_celeryext/__init__.py
@@ -121,7 +121,7 @@ Testing
 Testing your celery tasks is rather easy. First ensure that you Celery is
 configured to execute tasks eagerly and stores results in local memory:
 
-    >>> app = Flask("testapp")
+    >>> app = Flask("myapp")
     >>> app.config.update(dict(
     ...     CELERY_ALWAYS_EAGER=True,
     ...     CELERY_RESULT_BACKEND="cache",
@@ -139,7 +139,7 @@ And finally execute your task:
 
     >>> r = test.delay()
     >>> r.result
-    'testapp'
+    'myapp'
 """
 
 from __future__ import absolute_import, print_function, unicode_literals

--- a/flask_celeryext/app.py
+++ b/flask_celeryext/app.py
@@ -11,17 +11,19 @@
 
 from __future__ import absolute_import, print_function
 
-from celery import Celery, Task
+from celery import current_app as current_celery_app
+from celery import Task
 
 
 def create_celery_app(flask_app):
     """Create a Celery application."""
-    celery = Celery(flask_app.import_name)
+    celery = current_celery_app
     celery.conf.update(flask_app.config)
     celery.Task = AppContextTask
 
     # Set Flask application object on the Celery application.
-    celery.flask_app = flask_app
+    if not hasattr(celery, 'flask_app'):
+        celery.flask_app = flask_app
 
     return celery
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,6 +12,7 @@
 from __future__ import absolute_import, print_function
 
 import pytest
+from celery import Celery
 from flask import Flask, current_app, request
 
 from flask_celeryext import AppContextTask, RequestContextTask, \
@@ -19,7 +20,6 @@ from flask_celeryext import AppContextTask, RequestContextTask, \
 
 
 class eager_conf:
-
     """Configuration for testing Celery tasks."""
 
     CELERY_ALWAYS_EAGER = True
@@ -30,6 +30,10 @@ class eager_conf:
 
 def test_factory():
     """Test of factory method."""
+    # Set the current Celery application
+    c = Celery('mycurrent')
+    c.set_current()
+
     app = Flask("myapp")
     celery = create_celery_app(app)
     assert celery
@@ -40,6 +44,10 @@ def test_appctx_task():
     """Test execution of Celery task with application context."""
     app = Flask("myapp")
     app.config.from_object(eager_conf)
+
+    # Set the current Celery application
+    c = Celery('mycurrent')
+    c.set_current()
 
     celery = create_celery_app(app)
 


### PR DESCRIPTION
* INCOMPATIBLE Changes celery application creation to use the
  default current celery application instead creating a new celery
  application. This addresses an issue with tasks using the
  shared_task decorator and having   Flask-CeleryExt initialized
  multiple times.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>