### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
 Authors
 -------
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 * Lars Holm Nielsen <lars.holm.nielsen@cern.ch>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -35,7 +35,7 @@ Homepage
 Happy hacking and thanks for flying Flask-CeleryExt.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: http://github.com/inveniosoftware
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     url='http://github.com/inveniosoftware/flask-cli/',
     license='BSD',
     author='Invenio Collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description=__doc__,
     long_description=open('README.rst').read(),
     packages=['flask_celeryext', ],


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>