### PR TITLE
app: account for non-strict Celery versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Version 0.3.1 (released 2018-03-26)
+
+- Accounts for non-strict Celery versions.
+
 Version 0.3.0 (released 2017-03-24)
 
 - Adds support for Celery v4.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ========================
- Flask-CeleryExt v0.3.0
+ Flask-CeleryExt v0.3.1
 ========================
 
-Flask-CeleryExt v0.3.0 was released on March 24, 2017.
+Flask-CeleryExt v0.3.1 was released on March 26, 2018.
 
 About
 -----
@@ -12,12 +12,12 @@ Flask-CeleryExt is a simple integration layer between Celery and Flask.
 Changes
 -------
 
-- Adds support for Celery v4.
+- Accounts for non-strict Celery versions.
 
 Installation
 ------------
 
-   $ pip install flask-celeryext==0.3.0
+   $ pip install flask-celeryext==0.3.1
 
 Documentation
 -------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-CeleryExt
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2018 CERN.
 #
 # Flask-CeleryExt is free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for more
@@ -12,7 +12,6 @@ from __future__ import print_function
 import os
 
 import sphinx.environment
-
 
 # -- General configuration ------------------------------------------------
 

--- a/flask_celeryext/app.py
+++ b/flask_celeryext/app.py
@@ -14,9 +14,10 @@ from __future__ import absolute_import, print_function
 import warnings
 from distutils.version import LooseVersion
 
+from celery import Task
 from celery import __version__ as celery_version
 from celery import current_app as current_celery_app
-from celery import Task, signals
+from celery import signals
 
 from ._mapping import V3TOV4MAPPING
 

--- a/flask_celeryext/app.py
+++ b/flask_celeryext/app.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-CeleryExt
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018 CERN.
 #
 # Flask-CeleryExt is free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for more
@@ -12,7 +12,7 @@
 from __future__ import absolute_import, print_function
 
 import warnings
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 from celery import __version__ as celery_version
 from celery import current_app as current_celery_app
@@ -20,7 +20,7 @@ from celery import Task, signals
 
 from ._mapping import V3TOV4MAPPING
 
-CELERY_4_OR_GREATER = StrictVersion(celery_version) >= StrictVersion('4.0')
+CELERY_4_OR_GREATER = LooseVersion(celery_version) >= LooseVersion('4.0')
 
 
 def v3tov4config(config, mapping):

--- a/flask_celeryext/version.py
+++ b/flask_celeryext/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-CeleryExt
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018 CERN.
 #
 # Flask-CeleryExt is free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for more
@@ -18,4 +18,4 @@ from __future__ import absolute_import, print_function
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-CeleryExt
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018 CERN.
 #
 # Flask-CeleryExt is free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for more
@@ -19,7 +19,7 @@ history = open('CHANGES.rst').read()
 tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
-    'isort>=4.2.2',
+    'isort>=4.3.4',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',


### PR DESCRIPTION
Celery just published version `3.1.26_1` (https://github.com/celery/celery/commit/ec40d98ff52df2d8cc8e33fac4f6d5f09bd7cc8a), which is not allowed by `distutils`'s `StrictVersion`: http://epydoc.sourceforge.net/stdlib/distutils.version.StrictVersion-class.html.

The second commit relaxes this constraint by using instead `LooseVersion`, so that builds of applications using this package don't fail like this: https://travis-ci.org/inspirehep/inspire-next/jobs/357800693#L936.

The first commit instead fixes the build (as it was broken before: https://travis-ci.org/inveniosoftware/flask-celeryext/builds/302998370), while the third commit asks for a release.