### PR TITLE
Prevent nested app_context creation and release v0.3.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.3.2 (released 2019-06-20)
+
+- Uses correct Celery version for Python 3.7.
+- Prevents multiple creation and pushing of Flask application contexts.
+
 Version 0.3.1 (released 2018-03-26)
 
 - Accounts for non-strict Celery versions.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ========================
- Flask-CeleryExt v0.3.1
+ Flask-CeleryExt v0.3.2
 ========================
 
-Flask-CeleryExt v0.3.1 was released on March 26, 2018.
+Flask-CeleryExt v0.3.2 was released on June 20, 2019.
 
 About
 -----
@@ -17,7 +17,7 @@ Changes
 Installation
 ------------
 
-   $ pip install flask-celeryext==0.3.1
+   $ pip install flask-celeryext==0.3.2
 
 Documentation
 -------------

--- a/flask_celeryext/__init__.py
+++ b/flask_celeryext/__init__.py
@@ -132,9 +132,6 @@ increase significantly.
 The background worker on the other hand usually needs to load tasks upfront in
 order to know which tasks it can handle.
 
-See https://flask-appfactory.readthedocs.io for a solution on using
-Flask-CeleryExt in larger applications.
-
 Testing
 -------
 Testing your celery tasks is rather easy. First ensure that you Celery is

--- a/flask_celeryext/app.py
+++ b/flask_celeryext/app.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-CeleryExt
-# Copyright (C) 2015, 2016, 2017, 2018 CERN.
+# Copyright (C) 2015-2019 CERN.
+# Copyright (C) 2018-2019 infarm - Indoor Urban Farming GmbH.
 #
 # Flask-CeleryExt is free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for more
@@ -14,6 +15,7 @@ from __future__ import absolute_import, print_function
 import warnings
 from distutils.version import LooseVersion
 
+import flask
 from celery import Task
 from celery import __version__ as celery_version
 from celery import current_app as current_celery_app
@@ -75,6 +77,9 @@ class AppContextTask(Task):
 
     def __call__(self, *args, **kwargs):
         """Execute task."""
+        # If an "app_context" has already been loaded, just pass through
+        if flask._app_ctx_stack.top is not None:
+            return Task.__call__(self, *args, **kwargs)
         with self.app.flask_app.app_context():
             return Task.__call__(self, *args, **kwargs)
 

--- a/flask_celeryext/version.py
+++ b/flask_celeryext/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-CeleryExt
-# Copyright (C) 2015, 2016, 2017, 2018 CERN.
+# Copyright (C) 2015-2019 CERN.
 #
 # Flask-CeleryExt is free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for more
@@ -18,4 +18,4 @@ from __future__ import absolute_import, print_function
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-CeleryExt
-# Copyright (C) 2015, 2016, 2017, 2018 CERN.
+# Copyright (C) 2015-2019 CERN.
+# Copyright (C) 2018-2019 infarm - Indoor Urban Farming GmbH.
 #
 # Flask-CeleryExt is free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for more
@@ -25,6 +26,7 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
+    'pytest-mock>=1.6.0',
 ]
 
 extras_require = {


### PR DESCRIPTION
Because the app_teardown signal handler might be fired too soon
and other undesired side effects might pops up in case several app context
are created.

Can only be triggered if CELERY_ALWAYS_EAGER is True and subtasks are called.