### PR TITLE
Improve requires specification inside setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,6 @@ extras_require = {
     'docs': [
         'Sphinx>=1.4.2',
     ],
-    ':python_version<"3.7"': [
-            'celery>=3.1'
-        ],
-    ':python_version=="3.7"': [
-            'celery>=4.3'
-        ],
     'tests': tests_require,
 }
 
@@ -52,6 +46,8 @@ setup_requires = [
 
 install_requires = [
     'Flask>=0.10',
+    'celery>=3.1;python_version<"3.7"',
+    'celery>=4.3;python_version=="3.7"',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
The current requires specification inside `setup.py` is probably causing a problem with poetry (https://github.com/sdispater/poetry/issues/1238).

More info about the changes here: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies
