### PR TITLE
global: pin celery version for python<3.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Version 0.3.3 (released 2020-02-13)
+
+- fix celery version for Python < 3.7
+
 Version 0.3.2 (released 2019-06-25)
 
 - Uses correct Celery version for Python 3.7.

--- a/flask_celeryext/version.py
+++ b/flask_celeryext/version.py
@@ -18,4 +18,4 @@ from __future__ import absolute_import, print_function
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup_requires = [
 
 install_requires = [
     'Flask>=0.10',
-    'celery>=3.1;python_version<"3.7"',
+    'celery>=3.1,<4.3;python_version<"3.7"',
     'celery>=4.3;python_version=="3.7"',
 ]
 


### PR DESCRIPTION
The lack of upper limit of the version cause that f.e. for python 3.6 if we wanted the latest packages, it was still installing celery > 4.3 and causing issues