### PR TITLE
fix: ValueError introduced by pytest-pydocstyle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ tests =
     pytest-mock>=2.0.0
     pytest-black>=0.3.12
     pytest-pydocstyle>=2.2.0
-    pytest>=6,<7
+    pytest>=6,<7.2.0
     redis>=4.1.4
     Sphinx>=4.2.0
     importlib-metadata<5; python_version<"3.8"


### PR DESCRIPTION
* this commit fixes an 'ValueError: too many values to unpack' error.
  pydocstyle released the version 6.2.0 some days ago. This release
  changed the yield value of the 'get_files_to_check' method. by
  allowing also pytest < 7.2.0 it is possible to install
  pytest-pydocsstyle >= 2.3.0 which fixes the 'ValueError'.
